### PR TITLE
fix: add netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  publish = "dist"
+  command = "npm run export"


### PR DESCRIPTION
Currently when using the deploy to Netlify button one have to manually enter the build command and publish directory via the UI.

This change fixes the above.