### PR TITLE
Make README code links relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ The following instructions introduce common customization points like adding new
 
 ### Styling pages by a customized theme
 
-All source codes related to the blog are under [components](https://github.com/wutali/nextjs-netlify-blog-template/tree/master/src/components), [pages](https://github.com/wutali/nextjs-netlify-blog-template/tree/master/src/pages), and
-[layouts](https://github.com/wutali/nextjs-netlify-blog-template/tree/master/src/layouts) directory.
+All source codes related to the blog are under [components](/src/components), [pages](/src/pages), and
+[layouts](/src/layouts) directory.
 You can modify it freely if you want to apply your design theme.
 All components use [styled-jsx](https://github.com/vercel/styled-jsx) and [css-modules](https://github.com/css-modules/css-modules) to define their styles, but you can choose any styling libraries for designing your theme.
 
@@ -78,24 +78,24 @@ src
 The category metadata that associates with content have the same relationship with the authors' one.
 Then reference these implementations for adding new metadata:
 
-- [public/admin/config.yml](https://github.com/wutali/nextjs-netlify-blog-template/blob/master/public/admin/config.yml#L51): author metadata definition for Netlify CMS
-- [src/lib/authors.tsx](https://github.com/wutali/nextjs-netlify-blog-template/blob/master/src/lib/authors.ts): fetches metadata and defines utility functions for components
-- [meta/authors.yml](https://github.com/wutali/nextjs-netlify-blog-template/blob/master/src/meta/authors.yml): author content managed by Netlify CMS
-- [layouts/index.tsx](https://github.com/wutali/nextjs-netlify-blog-template/blob/master/src/layouts/index.tsx): displays author content for each page
+- [public/admin/config.yml](/public/admin/config.yml#L51): author metadata definition for Netlify CMS
+- [src/lib/authors.tsx](/src/lib/authors.ts): fetches metadata and defines utility functions for components
+- [meta/authors.yml](/src/meta/authors.yml): author content managed by Netlify CMS
+- [layouts/index.tsx](/src/layouts/index.tsx): displays author content for each page
 
 You understood they have four steps to add the category metadata on your project after you read the above source codes:
 
 1. Define the category metadata on the above Netlify config file
-2. Create an empty file named with `categories.yml` under [meta](https://github.com/wutali/nextjs-netlify-blog-template/blob/master/src/meta/) directory
+2. Create an empty file named with `categories.yml` under [meta](/src/meta/) directory
 3. Create a new module for fetching category metadata
-4. Display the category metadata on [layouts](https://github.com/wutali/nextjs-netlify-blog-template/blob/master/src/layouts/index.tsx#L71) or other components you want
+4. Display the category metadata on [layouts](/src/layouts/index.tsx#L71) or other components you want
 
 It is all you have to do. After that, you can access Netlify CMS and create new categories at any time.
 
 ### Locale settings for Netlify CMS
 
-Modify [config.yml](https://github.com/wutali/nextjs-netlify-blog-template/blob/master/public/admin/config.yml) and
-[index.html](https://github.com/wutali/nextjs-netlify-blog-template/blob/master/public/admin/index.html) under [public/admin](https://github.com/wutali/nextjs-netlify-blog-template/blob/master/public/admin/) directory
+Modify [config.yml](/public/admin/config.yml) and
+[index.html](/public/admin/index.html) under [public/admin](/public/admin/) directory
 as following instructions:
 
 [Netlify CMS - Configuration Options #Locale](https://www.netlifycms.org/docs/configuration-options/#locale)


### PR DESCRIPTION
After my accidental PR from #12 while trying to update `public/admin/config.yml` in my repo through GitHub, this is a PR to make all the repo links in `README.md` relative. This is so that anyone rushing through a similar change directly on GitHub will get pointed to their repo's versions of the referenced files, rather than the originals.

Sorry for the initial accidental notifications, and that it's taken me a while to get this out.

Also, while I'm here, this blog stack is fantastic, and has beaten everything else I've tried for what I want and need (and is so good that I'm actually beginning to blog semi-regularly), so thanks for sharing!