### PR TITLE
Fix overlapping quote symbols

### DIFF
--- a/src/components/PostLayout.tsx
+++ b/src/components/PostLayout.tsx
@@ -97,6 +97,7 @@ export default function PostLayout({
               margin: 0 auto;
               padding: 0 1.5rem;
               box-sizing: border-box;
+              z-index: 0;
             }
             .metadata div {
               display: inline-block;


### PR DESCRIPTION
Quote symbols assigned `z-index: -1` would be overlapped with its parent element.
![image](https://user-images.githubusercontent.com/23369968/114055173-7a259b00-98cb-11eb-8440-385eb77af648.png)
This can be fixed by creating a new stacking context.
![image](https://user-images.githubusercontent.com/23369968/114056010-354e3400-98cc-11eb-9dcc-1c2df87dcfb8.png)